### PR TITLE
[35기 김동규] 카카오 API 토큰 만료 추가

### DIFF
--- a/core/utils/kakao_api.py
+++ b/core/utils/kakao_api.py
@@ -2,10 +2,11 @@ import requests
 
 class KakaoAPI:
     def __init__(self, client_id, redirect_uri):
-        self.token_api     = "https://kauth.kakao.com/oauth/token"
-        self.user_info_api = "https://kapi.kakao.com/v2/user/me"
-        self.redirect_uri  = redirect_uri
-        self.client_id     = client_id
+        self.token_api        = "https://kauth.kakao.com/oauth/token"
+        self.user_info_api    = "https://kapi.kakao.com/v2/user/me"
+        self.expire_token_api = "https://kapi.kakao.com/v1/user/logout"
+        self.redirect_uri     = redirect_uri
+        self.client_id        = client_id
 
     def get_kakao_access_token(self, code):
         body = {
@@ -37,3 +38,12 @@ class KakaoAPI:
         }
 
         return user_kakao_info
+
+    def expire_user_access_token(self, kakao_token):
+        headers = {
+            'AUTHORIZATION' : f'Bearer {kakao_token}'
+            }
+
+        expire_token_res = requests.post(self.expire_token_api, headers=headers).json()
+
+        return expire_token_res


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 API로 발급된 토큰을 만료시키는 기능 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 카카오 토큰 만료 기능 추가
- 기존의 방식에서는 로그인 시 발급되는 토큰을 만료시키지 않음
- 로그인 시 사용자 정보를 불러오는데 토큰을 사용한 후 곧바로 토큰을 만료시키도록 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 없음

<br />

## :: 기타 질문 및 특이 사항
- 없음
