### PR TITLE
[35기 김동규] 회원 탈퇴 시 게시글 및 댓글 수정

### DIFF
--- a/core/utils/user_api.py
+++ b/core/utils/user_api.py
@@ -1,0 +1,35 @@
+from django.views import View
+from django.db import transaction
+from django.http import JsonResponse
+
+from users.models import User
+from posts.models import Post
+from comments.models import Comment
+
+class UserAPI(View):
+    def __init__(self, request):
+        self.user = request.user
+
+    def update_user_nickname(self, nickname):
+        try:
+            update = User.objects.get(id=self.user.id).update(nickname=nickname)
+
+            return update
+
+        except User.DoesNotExist:
+            return JsonResponse({'message' : 'user_does_not_exist'}, status = 404)
+
+    def delete_user_referenced_info(self):
+        null_user = User.objects.get_or_create(
+            kakao_id = 1234567890,
+            nickname = 'null',
+            email = 'null@null.com',
+            profile_image_url = 'null'
+        )
+
+        with transaction.atomic():
+            User.objects.get(id=self.user.id).delete()
+            Post.objects.filter(user_id=self.user.id).update(user_id=null_user.id)
+            Comment.objects.filter(user_id=self.user.id).update(user_id=null_user.id)
+
+        return 'success'

--- a/users/views.py
+++ b/users/views.py
@@ -4,8 +4,10 @@ from django.views import View
 from django.http  import JsonResponse
 from django.conf  import settings
 
+from core.utils.login_decorator import login_decorator
 from core.utils.kakao_api import KakaoAPI
-from users.models         import User
+from core.utils.user_api import UserAPI
+from users.models import User
 
 class KakaoSocialLoginView(View):
     def get(self, request):
@@ -30,3 +32,14 @@ class KakaoSocialLoginView(View):
         access_token = jwt.encode({'id' : user.id}, settings.SECRET_KEY, settings.ALGORITHM)
 
         return JsonResponse({'access_token' : access_token, 'message' : message}, status = 200)
+
+class UserView(View):
+    @login_decorator
+    def delete(self):
+        user_api = UserAPI()
+        delete_info = user_api.delete_user_referenced_info()
+
+        if not delete_info == 'success':
+            return JsonResponse({'message' : 'delete_failure'}, status = 400)
+
+        return JsonResponse({'message' : 'success'}, status = 200)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 회원 탈퇴 시 게시글 및 댓글을 가져오는 과정에서 오류 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 회원이 탈퇴할 경우 해당 회원에 대한 게시글 및 댓글 참조처리
- 게시글과 댓글이 참조하는 `user_id(Foreignkey)`를 null 회원을 참조하도록 수정
- 해당 회원이 탈퇴하여도 불러오는데 오류가 생기지 않도록 함

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 없음

<br />

## :: 기타 질문 및 특이 사항
- 없음
